### PR TITLE
fix(auth): bind balance reads to token subject (4MCA-M05 IDOR)

### DIFF
--- a/core/src/auth/access.rs
+++ b/core/src/auth/access.rs
@@ -75,6 +75,28 @@ pub fn require_user_match(auth: &AccessContext, user_address: &str) -> ServiceRe
     Ok(())
 }
 
+/// Binds a user-scoped read to the authenticated subject, allowing admin and
+/// facilitator roles to read cross-account (mirroring the clearing-proof
+/// handlers).
+pub fn require_user_match_or_privileged(
+    auth: &AccessContext,
+    user_address: &str,
+) -> ServiceResult<()> {
+    if !addresses_match(&auth.wallet_address, user_address)
+        && require_admin_role(auth).is_err()
+        && require_facilitator_role(auth).is_err()
+    {
+        warn!(
+            "auth user denied: wallet={}, role={}, user={}",
+            auth.wallet_address, auth.role, user_address
+        );
+        return Err(ServiceError::Unauthorized(
+            "user address does not match token subject and role is not privileged".into(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn require_admin_role(auth: &AccessContext) -> ServiceResult<()> {
     if !auth.role.trim().eq_ignore_ascii_case(ROLE_ADMIN) {
         return Err(ServiceError::Unauthorized("admin role required".into()));
@@ -93,7 +115,43 @@ pub fn require_facilitator_role(auth: &AccessContext) -> ServiceResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::scope_contains;
+    use super::super::constants::{ROLE_ADMIN, ROLE_FACILITATOR, ROLE_USER, SCOPE_PAYMENT_READ};
+    use super::{AccessContext, require_user_match_or_privileged, scope_contains};
+
+    fn ctx(wallet: &str, role: &str) -> AccessContext {
+        AccessContext {
+            wallet_address: wallet.to_string(),
+            role: role.to_string(),
+            scopes: vec![SCOPE_PAYMENT_READ.to_string()],
+        }
+    }
+
+    #[test]
+    fn require_user_match_or_privileged_allows_self() {
+        let auth = ctx("0xAbC", ROLE_USER);
+        // Case-insensitive match against the token subject.
+        assert!(require_user_match_or_privileged(&auth, "0xabc").is_ok());
+    }
+
+    #[test]
+    fn require_user_match_or_privileged_denies_other_user() {
+        // Regression test for 4MCA-M05: a plain user must not read another
+        // wallet's balance/exposure (IDOR).
+        let auth = ctx("0xAbC", ROLE_USER);
+        assert!(require_user_match_or_privileged(&auth, "0xdef").is_err());
+    }
+
+    #[test]
+    fn require_user_match_or_privileged_allows_admin_cross_account() {
+        let auth = ctx("0xAbC", ROLE_ADMIN);
+        assert!(require_user_match_or_privileged(&auth, "0xdef").is_ok());
+    }
+
+    #[test]
+    fn require_user_match_or_privileged_allows_facilitator_cross_account() {
+        let auth = ctx("0xAbC", ROLE_FACILITATOR);
+        assert!(require_user_match_or_privileged(&auth, "0xdef").is_ok());
+    }
 
     #[test]
     fn scope_contains_matches_case_insensitively() {

--- a/core/src/service/query.rs
+++ b/core/src/service/query.rs
@@ -32,6 +32,7 @@ impl CoreService {
         asset_address: String,
     ) -> ServiceResult<Option<AssetBalanceInfo>> {
         access::require_scope(auth, SCOPE_PAYMENT_READ)?;
+        access::require_user_match_or_privileged(auth, &user_address)?;
 
         let Some(balance) =
             repo::get_user_asset_balance(&self.inner.persist_ctx, &user_address, &asset_address)

--- a/core/tests/api_auth.rs
+++ b/core/tests/api_auth.rs
@@ -6,6 +6,7 @@ use alloy::signers::Signer;
 use alloy::signers::local::PrivateKeySigner;
 use anyhow::{Result, bail};
 use chrono::Utc;
+use core_service::auth::constants::ROLE_USER;
 use core_service::auth::constants::SCOPE_PAYMENT_READ;
 use core_service::auth::jwt::{AccessTokenClaims, validate_access_token};
 use core_service::config::{AuthConfig, DEFAULT_ASSET_ADDRESS};
@@ -259,6 +260,41 @@ async fn core_api_get_user_asset_balance() -> anyhow::Result<()> {
         .await
         .expect("unknown user balance");
     assert!(unknown_user.is_none());
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+#[serial_test::file_serial(db)]
+async fn core_api_get_user_asset_balance_denies_foreign_read_for_plain_user() -> anyhow::Result<()>
+{
+    let (config, _core_client, ctx, _auth) = setup_http_test_environment().await?;
+    let base_addr = core_base_url(&config);
+
+    let caller = PrivateKeySigner::random();
+    let caller_auth =
+        login_with_siwe(&base_addr, &ctx, &caller, ROLE_USER, &[SCOPE_PAYMENT_READ]).await?;
+    let caller_client =
+        rpc::RpcProxy::new(&base_addr)?.with_bearer_token(caller_auth.access_token.clone());
+
+    let foreign_user = random_address();
+    ensure_user_with_collateral(&ctx, &foreign_user, U256::from(15u64)).await?;
+
+    let err = caller_client
+        .get_user_asset_balance(foreign_user, DEFAULT_ASSET_ADDRESS.to_string())
+        .await
+        .expect_err("plain user must not read another wallet's balance");
+
+    match err {
+        rpc::ApiClientError::Api { status, message } => {
+            assert_eq!(status, reqwest::StatusCode::UNAUTHORIZED);
+            assert!(
+                message.contains("user address does not match token subject"),
+                "unexpected error message: {message}"
+            );
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
 
     Ok(())
 }

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -350,7 +350,7 @@ Notes:
 - `get_guarantee(tab_id: U256, req_id: U256) -> Result<Option<GuaranteeInfo>, RecipientQueryError>`: Get a specific guarantee by tab ID and request ID
 - `list_recipient_payments() -> Result<Vec<RecipientPaymentInfo>, RecipientQueryError>`: List all payments for the recipient
 - `get_collateral_events_for_tab(tab_id: U256) -> Result<Vec<CollateralEventInfo>, RecipientQueryError>`: Get collateral events for a specific tab
-- `get_user_asset_balance(user_address: String, asset_address: String) -> Result<Option<AssetBalanceInfo>, RecipientQueryError>`: Get user's asset balance
+- `get_user_asset_balance(asset_address: String) -> Result<Option<AssetBalanceInfo>, RecipientQueryError>`: Get the authenticated signer's asset balance
 
 > **Note:** `BLSCert` now exposes typed claims and signatures. Use `cert.claims().to_hex()` or `cert.signature().to_hex()` when you need hex strings.
 

--- a/sdk/src/client/recipient.rs
+++ b/sdk/src/client/recipient.rs
@@ -212,12 +212,12 @@ impl<S> RecipientClient<S> {
 
     pub async fn get_user_asset_balance(
         &self,
-        user_address: String,
         asset_address: String,
     ) -> Result<Option<AssetBalanceInfo>, RecipientQueryError>
     where
         S: Signer + Sync,
     {
+        let user_address = self.ctx.signer_address().to_string();
         let balance = self
             .ctx
             .rpc_proxy()

--- a/sdk/tests/common/mod.rs
+++ b/sdk/tests/common/mod.rs
@@ -164,7 +164,6 @@ pub fn extract_asset_info(assets: &[UserInfo], asset_address: Address) -> Option
 
 pub async fn wait_for_collateral_increase<S: Signer + Sync>(
     recipient_client: &RecipientClient<S>,
-    user_address: &str,
     asset_address: Address,
     starting_total: U256,
     increase_by: U256,
@@ -172,14 +171,13 @@ pub async fn wait_for_collateral_increase<S: Signer + Sync>(
     let poll_interval = Duration::from_millis(200);
     let timeout = Duration::from_secs(60);
     let start = Instant::now();
-    let user_address = user_address.to_string();
     let asset_address = asset_address.to_string();
     let target_total = starting_total + increase_by;
     let mut last_total = starting_total;
 
     loop {
         if let Some(balance) = recipient_client
-            .get_user_asset_balance(user_address.clone(), asset_address.clone())
+            .get_user_asset_balance(asset_address.clone())
             .await?
         {
             last_total = balance.total;
@@ -190,7 +188,7 @@ pub async fn wait_for_collateral_increase<S: Signer + Sync>(
 
         if start.elapsed() > timeout {
             bail!(
-                "timed out waiting for collateral increase to {target_total:?} for user {user_address}, last observed total {last_total:?}"
+                "timed out waiting for collateral increase to {target_total:?}, last observed total {last_total:?}"
             );
         }
 

--- a/sdk/tests/withdraw.rs
+++ b/sdk/tests/withdraw.rs
@@ -98,13 +98,12 @@ async fn test_withdrawal_finalization_grace_period_not_elapsed() -> anyhow::Resu
     )
     .await?;
 
-    let user_address = user_config.signer.address().to_string();
     let user_client = Client::new(user_config.clone()).await?;
 
     // Step 1: User deposits collateral (2 ETH)
     let core_total_before = user_client
         .recipient
-        .get_user_asset_balance(user_address.clone(), ETH_ASSET_ADDRESS.to_string())
+        .get_user_asset_balance(ETH_ASSET_ADDRESS.to_string())
         .await?
         .map(|info| info.total)
         .unwrap_or(U256::ZERO);
@@ -114,7 +113,6 @@ async fn test_withdrawal_finalization_grace_period_not_elapsed() -> anyhow::Resu
 
     wait_for_collateral_increase(
         &user_client.recipient,
-        &user_address,
         ETH_ASSET_ADDRESS,
         core_total_before,
         deposit_amount,
@@ -157,13 +155,12 @@ async fn test_withdrawal_insufficient_collateral() -> anyhow::Result<()> {
     )
     .await?;
 
-    let user_address = user_config.signer.address().to_string();
     let user_client = Client::new(user_config.clone()).await?;
 
     // Step 1: User deposits collateral (0.5 ETH)
     let core_total_before = user_client
         .recipient
-        .get_user_asset_balance(user_address.clone(), ETH_ASSET_ADDRESS.to_string())
+        .get_user_asset_balance(ETH_ASSET_ADDRESS.to_string())
         .await?
         .map(|info| info.total)
         .unwrap_or(U256::ZERO);
@@ -173,7 +170,6 @@ async fn test_withdrawal_insufficient_collateral() -> anyhow::Result<()> {
 
     wait_for_collateral_increase(
         &user_client.recipient,
-        &user_address,
         ETH_ASSET_ADDRESS,
         core_total_before,
         deposit_amount,


### PR DESCRIPTION
`get_user_asset_balance `only checked the `payment:read` scope and passed the attacker-controlled `user_address` straight to the repository, letting any authenticated wallet read another user's collateral, locked exposure, and account existence.
Add `require_user_match_or_privileged` and call it before any repo access to allow admin/facilitator cross-account reads (mirroring the clearing-proof handlers). Includes regression tests covering self, other-user, admin, and facilitator cases.